### PR TITLE
fix incorrect type in `preset-column-widths` example

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -1461,9 +1461,9 @@ Example:
 ```nix
 {
   programs.niri.settings.layout.preset-column-widths = [
-    { proportion = 1./3.; }
-    { proportion = 1./2.; }
-    { proportion = 2./3.; }
+    { proportion = 1. / 3.; }
+    { proportion = 1. / 2.; }
+    { proportion = 2. / 3.; }
 
     # { fixed = 1920; }
   ];


### PR DESCRIPTION
This was causing issues for me while rebuilding because `1. / 2.` is of type `float` while `1./2.` is of type `path`.